### PR TITLE
use \x0D\x0A instead of \r\n as recommended by 'perldoc perlport'.

### DIFF
--- a/lib/Text/vCard.pm
+++ b/lib/Text/vCard.pm
@@ -513,9 +513,12 @@ sub as_string {
             sort map { uc $_ } keys %{ $self->{nodes} };
     }
 
+    # 'perldoc perlport' says using \r\n is wrong and confusing for a few
+    # reasons but mainly because the value of \n is different on different
+    # operating systems.  It recommends \x0D\x0A instead.
+    my $newline = "\x0D\x0A";
     my $begin   = 'BEGIN:VCARD';
     my $end     = 'END:VCARD';
-    my $newline = "\r\n";
 
     my @lines = ($begin);
     for my $k (@k) {

--- a/lib/Text/vCard/Addressbook.pm
+++ b/lib/Text/vCard/Addressbook.pm
@@ -269,10 +269,14 @@ sub _pre_process_text {
         #
         # No longer needed in version 3.0:
         # http://tools.ietf.org/html/rfc2426 point (5)
+        #
+        # 'perldoc perlport' says using \r\n is wrong and confusing for a few
+        # reasons but mainly because the value of \n is different on different
+        # operating systems.  It recommends \x0D\x0A instead.
 
         my $out;
         my $inside = 0;
-        foreach my $line ( split( "\r\n", $text ) ) {
+        foreach my $line ( split( "\x0D\x0A", $text ) ) {
 
             if ($inside) {
                 if ( $line =~ /=$/ ) {
@@ -286,7 +290,7 @@ sub _pre_process_text {
                 $inside = 1;
                 $line =~ s/=$//;
             }
-            $out .= $line . "\r\n";
+            $out .= $line . "\x0D\x0A";
         }
         $text = $out;
 
@@ -296,8 +300,8 @@ sub _pre_process_text {
     my $asData = Text::vFile::asData->new;
     $asData->preserve_params(1);
 
-    my @lines = split "\r\n", $text;
-    my @lines_with_newlines = map { $_ . "\r\n" } @lines;
+    my @lines = split "\x0D\x0A", $text;
+    my @lines_with_newlines = map { $_ . "\x0D\x0A" } @lines;
     return $asData->parse_lines(@lines_with_newlines)->{objects};
 }
 

--- a/lib/Text/vCard/Node.pm
+++ b/lib/Text/vCard/Node.pm
@@ -490,10 +490,14 @@ sub _params {
 #
 # Don't escape anything if this is a base64 node.  Escaping only applies to
 # strings not binary values.
+#
+# 'perldoc perlport' says using \r\n is wrong and confusing for a few reasons
+# but mainly because the value of \n is different on different operating
+# systems.  It recommends \x0D\x0A instead.
 sub _escape {
     my ( $self, $val ) = @_;
     return $val if ( $self->is_type('b') or $self->is_type('base64') );
-    $val =~ s/(\r\n|\r|\n)/\n/g;
+    $val =~ s/(\x0D\x0A|\x0D|\x0A)/\x0A/g;
     $val =~ s/([,;|])/\\$1/g;
     return $val;
 }
@@ -505,10 +509,14 @@ sub _escape_list {
 
 # The vCard RFC says new lines must be \r\n
 # See http://tools.ietf.org/search/rfc6350#section-3.2
+#
+# 'perldoc perlport' says using \r\n is wrong and confusing for a few reasons
+# but mainly because the value of \n is different on different operating
+# systems.  It recommends \x0D\x0A instead.
 sub _newline {
     my ($self) = @_;
-    return "\r\n" if $self->{encoding_out} eq 'none';
-    return Encode::encode( $self->{encoding_out}, "\r\n" );
+    return "\x0D\x0A" if $self->{encoding_out} eq 'none';
+    return Encode::encode( $self->{encoding_out}, "\x0D\x0A" );
 }
 
 sub _decode_string {

--- a/t/05-export.t
+++ b/t/05-export.t
@@ -19,7 +19,7 @@ my $vcf = $adbk->export();
 
 like( $vcf, qr/TYPE=work/, 'export() - added type def' );
 
-my @lines = split( "\r\n", $vcf );
+my @lines = split( "\x0D\x0A", $vcf );    # \x0D\x0A == \r\n
 
 is( $lines[0],       'BEGIN:VCARD', 'export() - First line correct' );
 is( $lines[$#lines], 'END:VCARD',   'export() - Last line correct' );
@@ -39,7 +39,7 @@ my @data = (
     'FN:T-firstname T-surname',
     'END:VCARD',
 );
-@lines = split( "\r\n", $adbk->export() );
+@lines = split( "\x0D\x0A", $adbk->export() );    # \x0D\x0A == \r\n
 is_deeply(
     [ sort @lines ],
     [ sort @data ],
@@ -58,7 +58,8 @@ is_deeply(
     is $ab->export, '', 'export empty addressbook';
     my $vcard = $ab->add_vcard;
     isa_ok $vcard, 'Text::vCard';
-    like $ab->export, qr{^BEGIN:VCARD\s+END:VCARD\r\n$}, 'single empty vcard';
+    like $ab->export, qr{^BEGIN:VCARD\s+END:VCARD\x0D\x0A$},
+        'single empty vcard';
     $vcard->fullname('Foo Bar');
     $vcard->EMAIL('foo@bar.com');
     my $node = $vcard->add_node(

--- a/t/06-encoding.t
+++ b/t/06-encoding.t
@@ -30,7 +30,7 @@ my $a = $vcard->get(
     }
 )->[0];
 is( $a->street(),
-    "Software Development\r\n333 West River Park Drive",
+    "Software Development\x0D\x0A333 West River Park Drive",
     'Match on street'
 );
 is( $a->city(), 'Provo', 'Match on city' );

--- a/t/08-base64.t
+++ b/t/08-base64.t
@@ -43,7 +43,7 @@ CEX1MLtQoeSeUu1A+G777W/EuKONx8+Q/EI/Ko8ijS+quHwb0+PQPPLP+xQkKJRMWQqSn3RS5ZLj
 s2AKDlGmMiX541N5vpV0yflln3o6tQafZGpJ1vxcdQVmo1bxyZqagD//nek6BtyTWxRFPz3Jz4Gc
 wQthJChAPz1wTljBy1ry1KX8KRBTbekgn5IVMBKSik6Q4iAG2wJACCqqTVC5UwrpxKavnMOCb2Ah
 PkKIlDsZglCDCuH+1oRAQKHQhfEzijLWAKdjMHGEvHCOm+43RQJu0AWCwmIAxVFCExiSioJpupZm
-upisN4DxLye0lBrXyEYPRAAAOw==' . "\n";
+upisN4DxLye0lBrXyEYPRAAAOw==' . "\x0A";
 my $base64_image_decoded = MIME::Base64::decode($base64_image);
 is $photo->value, $base64_image_decoded, 'compare decoded values';
 

--- a/t/vcard/address_book.t
+++ b/t/vcard/address_book.t
@@ -104,7 +104,7 @@ sub expected_email_addresses {
 sub expected_out_file {
     my $in_file_string = $in_file->slurp( iomode => '<:encoding(UTF-8)' );
     return
-          "BEGIN:VCARD\r\nVERSION:4.0\r\nEND:VCARD\r\n" x 3
+          "BEGIN:VCARD\x0D\x0AVERSION:4.0\x0D\x0AEND:VCARD\x0D\x0A" x 3
         . $in_file_string
         . $in_file_string;
 }


### PR DESCRIPTION
I'm not sure why the tests are failing on win32.  This pull request is mostly a guess.

perldoc perlport says:

```
   Perl uses "\n" to represent the "logical" newline, where what is logical may depend on the platform in use.  In MacPerl, "\n" always means "\015".
   In DOSish perls, "\n" usually means "\012", but when accessing a file in "text" mode, STDIO translates it to (or from) "\015\012", depending on
   whether you're reading or writing.  Unix does the same thing on ttys in canonical mode.  "\015\012" is commonly referred to as CRLF.

  A common misconception in socket programming is that "\n" eq "\012" everywhere.  When using protocols such as common Internet protocols, "\012" and
   "\015" are called for specifically, and the values of the logical "\n" and "\r" (carriage return) are not reliable.

       print SOCKET "Hi there, client!\r\n";      # WRONG
       print SOCKET "Hi there, client!\015\012";  # RIGHT
```
